### PR TITLE
Add GitHub workflows to release and publish package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+# Upload a Python package to PyPI when a release is created
+#
+# For more information see:
+# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python package to PyPI
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+# Create a release using the version number from the Python package
+#
+# This workflow is designed to create a GitHub release whenever a pull request
+# is merged to the main branch that updates the version number for this repo's
+# Python package.
+#
+# The release is created with the tag and name of the version number.
+#
+# If there already exists a tag for the package version number the release
+# should not be created.
+
+name: Create a GitHub release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+
+      - name: Get package version
+        id: package_version
+        run: echo "::set-output name=python::"$(python setup.py --version)
+
+      - name: Check if version tag already exists
+        id: version_tag
+        uses: mukunku/tag-exists-action@f8003af57c02ede2638326be67523df10cf6b10a
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ steps.package_version.outputs.python }}
+
+      - name: Create GitHub release
+        if: ${{ steps.version_tag.outputs.exists == 'false' }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.DM_GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.package_version.outputs.python }}
+          release_name: Release v${{ steps.package_version.outputs.python }}


### PR DESCRIPTION
Ticket: https://trello.com/c/R6jfWwZh/2175-use-github-actions-to-publish-packages-to-pypi

We want to have this packaged published to PyPI automatically whenever a version bump is merged.