### PR TITLE
Optimise npm-install task for developer machines

### DIFF
--- a/dmdevtools/invoke_tasks.py
+++ b/dmdevtools/invoke_tasks.py
@@ -71,10 +71,23 @@ def freeze_requirements(c):
 @task
 def npm_install(c):
     """Install node.js dependencies"""
-    # If dependencies in the package lock do not match those in package.json,
-    # npm ci will exit with an error, instead of updating the package lock.
-    # (https://docs.npmjs.com/cli/ci.html)
-    c.run("npm ci")
+    if os.getenv("CI") == "true":
+        # On CI/GitHub Actions, install with a clean slate
+        # (https://docs.npmjs.com/cli/ci.html)
+        #
+        # If dependencies in the package lock do not match those in package.json,
+        # npm ci will exit with an error, instead of updating the package lockfile.
+        #
+        # If node_modules already exists, it will be removed.
+        c.run("npm ci")
+    else:
+        # On developer machine, install without updating package.json or
+        # package-lock.json.
+        #
+        # We want to save our disk drives and avoid reinstalling everything everytime,
+        # but we also want to avoid updating package lock files without realising it,
+        # so we add the `--no-save` option.
+        c.run("npm install --no-save")
 
 
 @task(npm_install)


### PR DESCRIPTION
It has been annoying me that running a task always rebuilds everything, this PR tweaks things a bit to mitigate.

On developer machines we don't want to run `npm ci` every time an invoke task is run because that means deleting the `node_modules` folder over and over again, so we add a conditional and if we aren't running on CI we use the normal `npm install` command.

We detect whether we are running on CI by using the `CI` environment variable, which is used by GitHub Actions[[1]].

We also want to avoid updating the package.json or package-lock.json files without the developer realising it, so we use the `--no-save` option with npm install[[2]].

[1]: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
[2]: https://docs.npmjs.com/cli/v7/commands/npm-install#configuration-options-affecting-build-process