### PR TITLE
Fix bootstrap install python requirements

### DIFF
--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -57,13 +57,6 @@ class TestVirtualenv:
 
 
 class TestInstallPythonRequirements:
-    def test_it_runs_pip_sync_if_local_pip_install_if_on_ci(self, ci):
-        context = MockContext(run=Result())
-        install_python_requirements(context)
-
-        command = context.run.call_args[0][0]
-        assert command.startswith("pip install" if ci else "pip-sync")
-
     def test_it_installs_requirements_from_requirements_txt_if_present(
         self, monkeypatch, tmp_path
     ):


### PR DESCRIPTION
The requirements tasks use `pip-compile` and `pip-sync`, which are part of [pip-tools](https://github.com/jazzband/pip-tools),  so we need to add `pip-tools` to the `venv` when installing requirements (if it isn't there already).