### PR TITLE
Add tasks to run mypy

### DIFF
--- a/dmdevtools/invoke_tasks.py
+++ b/dmdevtools/invoke_tasks.py
@@ -1,6 +1,7 @@
 import os
 import venv
 from pathlib import Path
+from typing import List
 
 from invoke import Collection, task
 
@@ -46,10 +47,11 @@ def upgrade_pip(c):
 
 
 def install_python_requirements(c, dev: bool = True):
+    requirements_files: List[Path]
     if dev:
-        requirements_files = Path().glob("requirements*.txt")
+        requirements_files = list(Path().glob("requirements*.txt"))
     else:
-        requirements_files = Path("requirements.txt")
+        requirements_files = [Path("requirements.txt")]
 
     if os.getenv("CI") == "true":
         install_command = f"pip install {' '.join(f'-r {f}' for f in requirements_files)}"

--- a/dmdevtools/invoke_tasks.py
+++ b/dmdevtools/invoke_tasks.py
@@ -125,6 +125,12 @@ def test_flake8(c):
     c.run("flake8 .")
 
 
+@task(virtualenv, requirements_dev)
+def test_mypy(c):
+    """Run python code linter"""
+    c.run("mypy")  # requires mypy.ini
+
+
 @task(virtualenv, requirements_dev, aliases=["test-unit"])
 def test_python(c, pytest_args=""):
     """Run python unit tests"""
@@ -178,6 +184,7 @@ _common_tasks = [
     requirements_dev,
     freeze_requirements,
     test_flake8,
+    test_mypy,
     test_python,
     show_environment,
 ]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+files = dmdevtools

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,5 @@
 [mypy]
 files = dmdevtools
+
+[mypy-invoke.*]
+ignore_missing_imports = True

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,6 @@
 -e file:.
 
 flake8
+mypy
 
 pip-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,11 +10,14 @@ flake8==3.8.4             # via -r requirements-dev.in
 importlib-metadata==3.3.0  # via flake8
 invoke==1.4.1             # via digitalmarketplace-developer-tools
 mccabe==0.6.1             # via flake8
+mypy-extensions==0.4.3    # via mypy
+mypy==0.812               # via -r requirements-dev.in
 pip-tools==5.4.0          # via -r requirements-dev.in
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
 six==1.15.0               # via pip-tools
-typing-extensions==3.7.4.3  # via importlib-metadata
+typed-ast==1.4.3          # via mypy
+typing-extensions==3.7.4.3  # via importlib-metadata, mypy
 zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,7 @@
 from dmdevtools.invoke_tasks import library_tasks as ns
 
+# test with mypy
+ns["test"].pre.insert(-1, ns["test-mypy"])
 
 # currently we have no unit tests
 ns["test"].pre.remove(ns["test-python"])


### PR DESCRIPTION
We use the static type checker [mypy] in some of our repos.

This commit adds a task `test-mypy` that can be run standalone or added to the list of default tests with

``` from dmdevtools.invoke_tasks import library_tasks as ns 
ns["test"].pre.insert(-1, ns["test-mypy"])
```

`test-mypy` runs `mypy` with no arguments, so it requires a `mypy.ini` config to tell mypy what to test:

```
[mypy]
files = dmdevtools
```

This PR also configures mypy for this repo and adds to the list of default tests that will be run with `invoke test` or with GitHub Actions.

[mypy]: http://mypy-lang.org/