### PR TITLE
Change virtualenv task to set PATH to venv only

### DIFF
--- a/dmdevtools/invoke_tasks.py
+++ b/dmdevtools/invoke_tasks.py
@@ -27,18 +27,8 @@ def virtualenv(c):
     c.virtual_env = Path(os.getenv("VIRTUAL_ENV", "venv"))
 
     venv_path = c.virtual_env.resolve() / "bin"
-    if not os.environ["PATH"].startswith(str(venv_path)):
-        print(f"\033[1;37mentering virtualenv at `{c.virtual_env}`\033[0m")
-        os.environ["PATH"] = f"{venv_path}:{os.getenv('PATH')}"
-
-    # skip if dry run
-    if not c.config["run"].get("dry"):
-        # we want to be sure that we are going to use python/pip from the venv
-        which_python = Path(c.run("which python", hide=True).stdout.strip())
-        expected_python = c.virtual_env / "bin" / "python"
-        assert which_python.samefile(expected_python), \
-            f"expected `which python` to return {expected_python}, instead got {which_python}" \
-            f"\nPATH={os.environ['PATH']}"
+    print(f"\033[1;37mentering virtualenv at `{c.virtual_env}`\033[0m")
+    os.environ["PATH"] = f"{venv_path}"
 
 
 @task(virtualenv)


### PR DESCRIPTION
We found a bug where if pip-sync wasn't installed in the venv but was installed in a wider environment, then pip-sync would run in that environment and trash your python installation. This is not desirable.

This commit changes the task `virtualenv` so that now the venv bin folder will be the only directory in `PATH`; the downside of this is that the only commands usable for tasks in this repo will be Python commands, the upside is that we won't accidentally trash people's installations.