### PR TITLE
Revert "Change virtualenv task to set PATH to venv only"

### DIFF
--- a/dmdevtools/invoke_tasks.py
+++ b/dmdevtools/invoke_tasks.py
@@ -27,8 +27,18 @@ def virtualenv(c):
     c.virtual_env = Path(os.getenv("VIRTUAL_ENV", "venv"))
 
     venv_path = c.virtual_env.resolve() / "bin"
-    print(f"\033[1;37mentering virtualenv at `{c.virtual_env}`\033[0m")
-    os.environ["PATH"] = f"{venv_path}"
+    if not os.environ["PATH"].startswith(str(venv_path)):
+        print(f"\033[1;37mentering virtualenv at `{c.virtual_env}`\033[0m")
+        os.environ["PATH"] = f"{venv_path}:{os.getenv('PATH')}"
+
+    # skip if dry run
+    if not c.config["run"].get("dry"):
+        # we want to be sure that we are going to use python/pip from the venv
+        which_python = Path(c.run("which python", hide=True).stdout.strip())
+        expected_python = c.virtual_env / "bin" / "python"
+        assert which_python.samefile(expected_python), \
+            f"expected `which python` to return {expected_python}, instead got {which_python}" \
+            f"\nPATH={os.environ['PATH']}"
 
 
 @task(virtualenv, aliases=["upgrade-pip"])

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -25,34 +25,38 @@ def ci(request, monkeypatch):
 
 
 class TestVirtualenv:
-    def test_it_creates_venv_if_it_does_not_exist(self, tmp_path, monkeypatch):
+    @pytest.fixture
+    def context(self, tmp_path):
+        context = MockContext()
+        context["run"]["dry"] = True
+        return context
+
+    def test_it_creates_venv_if_it_does_not_exist(self, tmp_path, monkeypatch, context):
         monkeypatch.chdir(tmp_path)
 
         assert not (tmp_path / "venv").exists()
 
-        virtualenv(MockContext())
+        virtualenv(context)
 
         assert (tmp_path / "venv").exists()
 
-    def test_it_enters_venv(self, tmp_path, monkeypatch):
+    def test_it_enters_venv(self, tmp_path, monkeypatch, context):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "venv").touch()
-        monkeypatch.delenv("PATH")
 
-        virtualenv(MockContext())
+        virtualenv(context)
 
-        assert os.environ["PATH"] == str(tmp_path / "venv" / "bin")
+        assert os.environ["PATH"].startswith(str(tmp_path / "venv" / "bin"))
 
-    def test_it_respects_virtual_env_envvar(self, tmp_path, monkeypatch):
+    def test_it_respects_virtual_env_envvar(self, tmp_path, monkeypatch, context):
         monkeypatch.chdir(tmp_path)
-        monkeypatch.delenv("PATH")
 
         (tmp_path / "venv-py39").touch()
         monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / "venv-py39"))
 
-        virtualenv(MockContext())
+        virtualenv(context)
 
-        assert os.environ["PATH"] == str(tmp_path / "venv-py39" / "bin")
+        assert os.environ["PATH"].startswith(str(tmp_path / "venv-py39" / "bin"))
         assert not (tmp_path / "venv").exists()
 
 


### PR DESCRIPTION
This reverts commit 0c4fc8e930dc52d2e0c815a1c7d200952784f860.

The above commit broke digitalmarketplace-api, which requires `pg_config` to be in path when being installed [[1]].

However changes to `install_pip_tools` in commit b2801104 should mitigate against any issues with `pip-sync` 🤞 

[1]: https://www.psycopg.org/docs/install.html