### PR TITLE
Fix invoke task for mypy

### DIFF
--- a/dmdevtools/invoke_tasks.py
+++ b/dmdevtools/invoke_tasks.py
@@ -133,7 +133,7 @@ def test_flake8(c):
 @task(virtualenv, requirements_dev)
 def test_mypy(c):
     """Run python code linter"""
-    c.run("mypy")  # requires mypy.ini
+    c.run("mypy .")  # requires mypy.ini
 
 
 @task(virtualenv, requirements_dev, aliases=["test-unit"])

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+ # type: ignore
+
 import re
 import ast
 import setuptools

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
- # type: ignore
+# type: ignore
 
 import re
 import ast

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -2,7 +2,7 @@ import os
 
 from invoke import MockContext, Result
 
-import pytest # type: ignore
+import pytest  # type: ignore
 
 from dmdevtools.invoke_tasks import install_python_requirements, virtualenv
 

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -2,7 +2,7 @@ import os
 
 from invoke import MockContext, Result
 
-import pytest
+import pytest # type: ignore
 
 from dmdevtools.invoke_tasks import install_python_requirements, virtualenv
 


### PR DESCRIPTION
Why this PR? I tried launching `invoke mypy` from the api app but `mypy` was complaining. Then, I tried to run the command (just `mypy`) on the shell and I got the same error. Changing to `mypy .` seems to work.

I think we haven't been realising about this issue because we don't invoke the `mypy` task in this repo via Github Actions CI, and the other repos overwrite the task or don't use it.

I'd need this to be fixed as I am trying to invoke the mypy task for the CI of `dmp-contained`, and I'd like to use the one offered in this repo.

As part of this, I also did something about the errors now flagged up by mypy on this repo. Disputably, I've set to ignore the type errors on setup.py. That was because I think that's a standard file that we hardly change and the errors seemed quite difficult to fix:
```
setup.py:10: error: Item "None" of "Optional[Match[str]]" has no attribute "group"
setup.py:13: error: Incompatible types in assignment (expression has type "TextIO", variable has type "BinaryIO")
```
This PR is an improvement anyway as it fixes an invoke task that was not working.